### PR TITLE
Add functionality to set the device id from the knock data, added unit tests for them, all tests pass

### DIFF
--- a/knockserver/models.py
+++ b/knockserver/models.py
@@ -10,6 +10,14 @@ class User(Base):
     salt = Column(String)
     username = Column(String)
 
+    @staticmethod
+    def get_user():
+        """
+        Get the first user object (the only allowed one)
+        :return: The user object
+        """
+        return User.query.first()
+
 class AccessPattern(Base):
     __tablename__ = 'accesspattern'
     id = Column(BigInteger().with_variant(Integer, "sqlite"), primary_key=True)
@@ -60,9 +68,25 @@ class ProfileJoin(Base):
     user_id = Column(Integer, ForeignKey('user.id'))
     door_name = Column(String)
 
+    @staticmethod
+    def get_profile():
+        """
+        Use this method to get a related profile
+        :return: The profile object
+        """
+        return ProfileJoin.query.filter(User.id == User.get_user().id).first()
+
 class Device(Base):
     __tablename__ = 'device'
     id = Column(BigInteger().with_variant(Integer, "sqlite"), primary_key=True)
     failure_count = Column(BigInteger)
     identifier = Column(String)
     name = Column(String)
+
+    @staticmethod
+    def get_device():
+        """
+        Use this method to get a related device
+        :return: The device object
+        """
+        return Device.query.filter(Device.id == ProfileJoin.get_profile().device_id).first()

--- a/knockserver/views.py
+++ b/knockserver/views.py
@@ -79,9 +79,7 @@ def patterns_post():
         pattern.max_uses = -1
     if 'device_id' in data:
         device_id = data['device_id']
-        user_id = User.query.first().id
-        profile = ProfileJoin.query.filter(User.id == user_id).first()
-        device = Device.query.filter(Device.id == profile.device_id).first()
+        device = Device.get_device()
         device.identifier = device_id
 
     # Fields that always are initialized to the same value
@@ -146,9 +144,19 @@ def knock():
         # Grab the current pattern pieces
         received_pattern_pieces = data['pattern']
 
+        # Get the Profile
+        profile = ProfileJoin.get_profile()
+
         # Filter out all expired knocks
         match_patterns = AccessPattern.query.filter(AccessPattern.expiration > time.time())
+
+        # Filter for all match patterns with the current device id
+        filtered_match_patterns = []
         for pattern in match_patterns:
+            if pattern.id == profile.pattern_id:
+                filtered_match_patterns.append(pattern)
+
+        for pattern in filtered_match_patterns:
 
             # Check to make sure number of pieces match
             if (len(received_pattern_pieces) != len(pattern.pattern_pieces)) or (len(pattern.pattern_pieces) <= 0):

--- a/knockserver/views.py
+++ b/knockserver/views.py
@@ -90,8 +90,6 @@ def patterns_post():
     pattern.pending = True
 
     db_session.add(pattern)
-    if device in locals():
-        db_session.add(device)
     db_session.commit()
 
     return jsonify(success=True)

--- a/knockserver/views.py
+++ b/knockserver/views.py
@@ -117,7 +117,6 @@ def knock():
     data = request.get_json(force=True)  # Converts request body json into python dict
 
     # Check for pending knock
-    user = User.query.first()
     pending_pattern = AccessPattern.query.filter(AccessPattern.pending == True).first()
 
     if pending_pattern is not None:

--- a/test_matching.py
+++ b/test_matching.py
@@ -17,6 +17,7 @@ class KnockServerTestCase(unittest.TestCase):
         database.silent_remove_test_db()
 
     def test_empty_db_no_match(self):
+        KnockServerTestCase.env_setup()
         resp = self.app.post(
             '/knock/',
             data=json.dumps({"pattern": [123, 123, 123]}),
@@ -28,7 +29,6 @@ class KnockServerTestCase(unittest.TestCase):
         self.assertEqual(data['success'], False)
 
     def test_perfect_match(self):
-
         KnockServerTestCase.env_setup()
 
         stored_pattern = models.AccessPattern()
@@ -90,9 +90,7 @@ class KnockServerTestCase(unittest.TestCase):
         pending_pattern = models.AccessPattern.query.filter(models.AccessPattern.pending == pending).first()
         self.assertIsNotNone(pending_pattern, "Pending pattern not found")
 
-        user = models.User.query.first()
-        profile = models.ProfileJoin.query.filter(models.ProfileJoin.user_id == user.id).first()
-        device = models.Device.query.filter(models.Device.id == profile.device_id).first()
+        device = models.Device.get_device()
 
         # Check the new pattern object
         self.assertEqual(pending_pattern.name, name, "Name is incorrect")
@@ -116,7 +114,6 @@ class KnockServerTestCase(unittest.TestCase):
     def env_setup():
         """
         Utilize this helper function to initialize all the user profile stuff for testing
-        :return:
         """
         stored_device = models.Device()
         stored_device.failure_count = 1

--- a/test_matching.py
+++ b/test_matching.py
@@ -29,6 +29,95 @@ class KnockServerTestCase(unittest.TestCase):
 
     def test_perfect_match(self):
 
+        KnockServerTestCase.env_setup()
+
+        stored_pattern = models.AccessPattern()
+        stored_pattern.active = True
+        stored_pattern.name = "Test Pattern 1"
+        stored_pattern.pending = False
+        stored_pattern.used_count = 0
+
+        # Make this access pattern expire in the future by a significant amount of seconds
+        stored_pattern.expiration = time.time() + 10000
+
+        for i in range(3):
+            piece = models.PatternPiece()
+            piece.length = 123
+            piece.order = i
+            # First int is pressed time so all even indexed values are pressed
+            piece.pressed = i % 2 == 0
+
+            stored_pattern.pattern_pieces.append(piece)
+
+        db_session.add(stored_pattern)
+        db_session.commit()
+
+        resp = self.app.post(
+            '/knock/',
+            data=json.dumps({"pattern": [123, 123, 123]}),
+            content_type='application/json',
+            follow_redirects=True
+        )
+
+        data = json.loads(resp.data.decode())
+        self.assertEqual(data['success'], True)
+
+    def test_pending_pattern(self):
+        pending = True
+        name = "test name"
+        expiration = 6
+        max_uses = 100
+        device_id = "01:23:45:67:89"
+        active = True
+        used_count = 0
+
+        KnockServerTestCase.env_setup()
+
+        # First check to see if there are no pending patterns in the db
+        pending_pattern = models.AccessPattern.query.filter(models.AccessPattern.pending == True).first()
+        self.assertIsNone(pending_pattern, "Pending pattern found before test started")
+
+        # Now try to create a pending pattern
+        resp = self.app.post(
+            '/patterns/',
+            data=json.dumps({"name": name,
+                             "expiration": expiration,
+                             "max_uses": max_uses,
+                             "device_id": device_id}),
+            content_type='application/json',
+            follow_redirects=True
+        )
+        pending_pattern = models.AccessPattern.query.filter(models.AccessPattern.pending == pending).first()
+        self.assertIsNotNone(pending_pattern, "Pending pattern not found")
+
+        user = models.User.query.first()
+        profile = models.ProfileJoin.query.filter(models.ProfileJoin.user_id == user.id).first()
+        device = models.Device.query.filter(models.Device.id == profile.device_id).first()
+
+        # Check the new pattern object
+        self.assertEqual(pending_pattern.name, name, "Name is incorrect")
+        self.assertEqual(pending_pattern.expiration, expiration, "Expiration is incorrect")
+        self.assertEqual(pending_pattern.max_uses, max_uses, "Max uses is incorrect")
+        self.assertEqual(pending_pattern.active, active, "Active is incorrect")
+        self.assertEqual(pending_pattern.used_count, used_count, "Used count is incorrect")
+
+        # Check the device object
+        self.assertEqual(device.identifier, device_id, "Device ID is incorrect")
+
+        # Check that we got success
+        data = json.loads(resp.data.decode())
+        self.assertEqual(data['success'], True)
+
+    # - Can ignore an empty button press (This should never happen but we should check for this)
+    # - Can detect if the length of two button press patterns are different.
+    # - Can detect if the length of two button press patterns are the same.
+
+    @staticmethod
+    def env_setup():
+        """
+        Utilize this helper function to initialize all the user profile stuff for testing
+        :return:
+        """
         stored_device = models.Device()
         stored_device.failure_count = 1
         stored_device.name = "TestDevice1"
@@ -57,47 +146,11 @@ class KnockServerTestCase(unittest.TestCase):
         stored_preferences.success_threshold = 1
         stored_preferences.failure_endpoint = "knock_failed"
 
-
-
-        stored_pattern = models.AccessPattern()
-        stored_pattern.active = True
-        stored_pattern.name = "Test Pattern 1"
-        stored_pattern.pending = False
-        stored_pattern.used_count = 0
-
-        # Make this access pattern expire in the future by a significant amount of seconds
-        stored_pattern.expiration = time.time() + 10000
-
-        for i in range(3):
-            piece = models.PatternPiece()
-            piece.length = 123
-            piece.order = i
-            # First int is pressed time so all even indexed values are pressed
-            piece.pressed = i % 2 == 0
-
-            stored_pattern.pattern_pieces.append(piece)
-
         db_session.add(stored_device)
         db_session.add(stored_user)
         db_session.add(stored_profile)
         db_session.add(stored_preferences)
-        db_session.add(stored_pattern)
         db_session.commit()
-
-        resp = self.app.post(
-            '/knock/',
-            data=json.dumps({"pattern": [123, 123, 123]}),
-            content_type='application/json',
-            follow_redirects=True
-        )
-
-        data = json.loads(resp.data.decode())
-        self.assertEqual(data['success'], True)
-
-    # - Can ignore an empty button press (THis should never happen but we should check for this)
-    # - Can detect if the length of two button press patterns are different.
-    # - Can detect if the length of two button press patterns are the same.
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
-Adds device ID to device from incoming post data from sensor tag app (during pending pattern functionality)
-Filter knock recognition patterns for the ones matching the current profile
-Adds unit tests to test this functionality, all existing and old unit tests pass